### PR TITLE
Oo qa

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -2,4 +2,4 @@
 # The logic to start up your application should be put in this
 # script. The application will work only if it binds to
 # $OPENSHIFT_DIY_IP:8080
-nohup $OPENSHIFT_REPO_DIR/diy/oo-install-server.rb $OPENSHIFT_DIY_IP $OPENSHIFT_DATA_DIR |& /usr/bin/logshifter -tag oo &
+nohup $OPENSHIFT_REPO_DIR/diy/oo-install-server.rb $OPENSHIFT_DIY_IP $OPENSHIFT_DATA_DIR $OPENSHIFT_APP_DNS |& /usr/bin/logshifter -tag oo &

--- a/diy/oo-install-server.rb
+++ b/diy/oo-install-server.rb
@@ -4,7 +4,13 @@ include WEBrick
 
 BIND_ADDRESS=ARGV[0]
 DOCUMENT_ROOT=ARGV[1]
-MAIN_SITE='install.openshift.com'
+APP_URL=ARGV[2]
+
+if APP_URL == 'oo-install.rhcloud.com'
+  MAIN_SITE='install.openshift.com'
+else
+  MAIN_SITE=APP_URL
+end
 
 @config = {
   :Port => 8080,


### PR DESCRIPTION
Update logging to use logshifter (now logs to app-root/logs/oo.log instead of app-root/logs/server.log)

Use $OPENSHIFT_APP_DNS to disable the install.openshift.com redirect if this is not the prod site.
