### PR TITLE
Allow for override of app url in update_package.sh

### DIFF
--- a/update_package.sh
+++ b/update_package.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-cd ../openshift-extras/oo-install && bundle exec rake package
+ARGS=""
+if [ -n "$1" ]; then
+  ARGS="APP_URL='$1'"
+fi
+
+cd ../openshift-extras/oo-install && bundle exec rake package $ARGS
 cd ../../oo/
 ssh oo-install 'rm -rf $OPENSHIFT_DATA_DIR/*'
 scp -r ../openshift-extras/oo-install/package/* oo-install:/var/lib/openshift/${OO_APP_USER}/app-root/data/


### PR DESCRIPTION
If update package is given an argument, this is passed in as as the
APP_URL env variable when running the package rake task in
openshift-extras/oo-install.
