### PR TITLE
Improvements to update_package.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,28 +7,28 @@ The DIY app itself is very simple; it serves the contents of `$OPENSHIFT_DATA_DI
 ## How to Update the Site Contents
 The web server logic for the `oo` application lives in this codebase. However, the files that are served by the app are stored in `$OPENSHIFT_DATA_DIR`. The site contents are repackaged and pushed to the `oo` application gear using the `update_package.sh` script that is part of this application.
 
-### One-Time Setup
-The `update_package.sh` script depends on two pre-configured settings.
-
-First, in your `.ssh/config` file, set up an entry for `oo-install`:
-
-    Host oo-install
-      HostName oo-install.rhcloud.com
-      User <oo application user ID>
-      IdentityFile <your key file>
-
-Second, in your `.bashrc` or `.bash_profile` file, create an environment variable for the `oo` application's user ID:
-
-    export OO_APP_USER='<oo application user ID>'
-
-Make sure to `source` that file if you want to try running updates straight away.
-
 ### Running the Updates
 1. Make sure that the `oo` repo is cloned into the same directory as the [openshift-extras](https://github.com/openshift/openshift-extras) repo.
 2. `cd` into the `oo` directory.
-3. Run `./update_package.sh`
+3. Run `./update_package.sh -s <user>@<hostname>`
+
+Where `<user>` is the uuid for your openshift application hosting `oo` and `<hostname>` is the application dns name. These values can be retrieved by running `rhc apps`.
 
 Under normal circumstances, this will be sufficient to update the `oo` application with the latest complete set of `oo-install` distribution files.
 
 ## How to Change the Site Contents
 If you examine the contents of `update_package.sh`, you will see that all of the heavy lifting is actually being done in the `openshift-extras` repo. The update script simply calls the "package" rake task from `openshift-extras/oo-install/Rakefile`, replaces the old site contents with the new, and then restarts the `oo` application. Therefore, any major changes to organization of the installer site must be performed in the installer's own [Rakefile](https://github.com/openshift/openshift-extras/blob/master/oo-install/Rakefile).
+
+### Optional Setup
+To avoid having to set flags when running `update_package.sh`, you can
+add a Host entry in your .ssh/config file for oo-install:
+```
+    Host oo-install
+      HostName <hostname>
+      User <user>
+      IdentityFile <keyfile>
+```
+Where `<user>` is the uuid for your openshift application hosting `oo` and `<hostname>` is the application dns name. These values can be retrieved by running `rhc apps`.
+
+`<keyfile>` is the private key corresponding to one of the public ssh keys defined in your openshift account. SSH keys can be verified from the management console (https://openshift.redhat.com/app/console/settings for OpenShift Online).
+

--- a/update_package.sh
+++ b/update_package.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
+set -eu
 
 usage(){
   cat << EOF
-  Usage: $0 [-h] [-u <app url>] [-l]
+  Usage: $0 [-h] [-s <ssh host>] [-u <app url>] [-l]
 
   -h             Display this help and exit
 
-  -u <app url>   If specified overrides the deployed application URL in 
+  -s <ssh host>  SSH address for the gear where the oo app is deployed.
+                 (default: oo-install)
+
+  -u <app url>   If specified overrides the deployed application URL in
                  generated packages (default: install.openshift.com).
+                 This value is ignored if deploying to
+                 oo-install.rhcloud.com.
 
   -l             Use local install script.  If not specified the
                  Enterprise install scripts are pulled from the official
@@ -17,14 +23,18 @@ EOF
 
 APP_URL=""
 USE_LOCAL_SCRIPT=false
+SSH_HOST="oo-install"
 
-while getopts :hu:l option; do
+while getopts :hu:s:l option; do
   case $option in
-    h) 
+    h)
       usage
       exit 1
       ;;
-    u) 
+    s)
+      SSH_HOST=$OPTARG
+      ;;
+    u)
       APP_URL=$OPTARG
       ;;
     l)
@@ -32,6 +42,30 @@ while getopts :hu:l option; do
       ;;
   esac
 done
+
+echo -e "\n\n#####################################################"
+echo "Using ${SSH_HOST} as the SSH host"
+echo -e "#####################################################\n\n"
+sleep 5
+
+if [ "x$APP_URL" == "x" ]; then
+  echo 'Attempting to retrieve $OPENSHIFT_APP_DNS value from app...'
+  app_url=$(ssh ${SSH_HOST} 'echo $OPENSHIFT_APP_DNS')
+
+  if [ "x$app_url" == "x" ]; then
+    echo 'Could not retrieve $OPENSHIFT_APP_DNS value from host'
+    exit 1
+  elif [ "$app_url" == "oo-install.rhcloud.com" ]; then
+    APP_URL="install.openshift.com"
+  else
+    APP_URL=$app_url
+  fi
+fi
+
+echo -e "\n\n#####################################################"
+echo "Using ${APP_URL} as the application URL"
+echo -e "#####################################################\n\n"
+sleep 5
 
 ARGS=""
 if [ "x$APP_URL" != "x" ]; then
@@ -42,9 +76,19 @@ if $USE_LOCAL_SCRIPT; then
   ARGS+=" USE_LOCAL_SCRIPT=1"
 fi
 
-cd ../openshift-extras/oo-install && bundle _1.3.5_ exec rake package $ARGS
-cd ../../oo/
-ssh oo-install 'rm -rf $OPENSHIFT_DATA_DIR/*'
-scp -r ../openshift-extras/oo-install/package/* oo-install:/var/lib/openshift/${OO_APP_USER}/app-root/data/
-ssh oo-install 'gear restart --cart diy'
+echo "Generating packages for deployment..."
+pushd ../openshift-extras/oo-install
+bundle _1.3.5_ exec rake package $ARGS
+
+popd
+
+echo "Removing existing deployment files..."
+ssh ${SSH_HOST} 'rm -rf app-root/data/*'
+
+echo "Copying new deployment files to app..."
+scp -r ../openshift-extras/oo-install/package/* ${SSH_HOST}:app-root/data/
+
+echo "Restarting app..."
+ssh ${SSH_HOST} 'gear restart --cart diy'
+
 exit


### PR DESCRIPTION
- update_package.sh
  - Add set -eu
  - Add -s flag to specify ssh_host to deploy to
  - No longer rely on OO_APP_USER env variable
  - Determine the application url from the deployed application,
    the -u flag will override this behavior, unless the application
    is oo-install.rhcloud.com
  - If deploying to oo-install.rhcloud.com set the URL to
    install.openshift.com whether -u is set or not.
  - Add some additional user output and add 5 second sleeps to
    allow a user to exit the script if the wrong host or url is
    detected.
